### PR TITLE
chore: fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,7 +975,7 @@ We need to define the functions in
 
 ```elixir
 def checked?(item) do
-  is_nil(item.status) and item.status > 0
+  not is_nil(item.status) and item.status > 0
 end
 
 def completed?(item) do
@@ -1082,7 +1082,7 @@ Open
 and add the following test to it:
 
 ```elixir
-test "delete_item/1 soft-deltes an item" do
+test "delete_item/1 soft-deletes an item" do
   item = item_fixture()
   assert {:ok, %Item{} = deleted_item} = Item.delete_item(item.id)
   assert deleted_item.status == 2


### PR DESCRIPTION
- fix checked?/1 function `is_nil(item.status)` -> `not is_nil(items.status)`
- fix typo issue `test "delete_item/1 soft-deletes an item" do` -> `test "delete_item/1 soft-deletes an item" do`

issue #91