### PR TITLE
change database from postgresql to sqlite 

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,12 +2,10 @@ import Mix.Config
 
 # Configure your database
 config :live_view_todo, LiveViewTodo.Repo,
-  username: "postgres",
-  password: "postgres",
-  database: "live_view_todo_dev",
-  hostname: "localhost",
-  show_sensitive_data_on_connection_error: true,
-  pool_size: 10
+  database: Path.expand("../live_view_todo_dev.db", Path.dirname(__ENV__.file)),
+  pool_size: 5,
+  stacktrace: true,
+  show_sensitive_data_on_connection_error: true
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,10 +6,10 @@ import Mix.Config
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
 config :live_view_todo, LiveViewTodo.Repo,
-  username: "postgres",
-  password: "postgres",
-  database: "live_view_todo_test#{System.get_env("MIX_TEST_PARTITION")}",
-  hostname: "localhost",
+  database: Path.expand("../live_view_todo_test.db", Path.dirname(__ENV__.file)),
+  pool_size: 5,
+
+
   pool: Ecto.Adapters.SQL.Sandbox
 
 # We don't run a server during test. If one is required,

--- a/lib/live_view_todo/repo.ex
+++ b/lib/live_view_todo/repo.ex
@@ -1,5 +1,5 @@
 defmodule LiveViewTodo.Repo do
   use Ecto.Repo,
     otp_app: :live_view_todo,
-    adapter: Ecto.Adapters.Postgres
+    adapter: Ecto.Adapters.SQLite3
 end

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule LiveViewTodo.MixProject do
       {:phoenix, "~> 1.7.0"},
       {:phoenix_ecto, "~> 4.4"},
       {:ecto_sql, "~> 3.10.1"},
-      {:postgrex, ">= 0.0.0"},
+      {:ecto_sqlite3, ">= 0.0.0"},
       {:phoenix_live_view, "~> 0.18"},
       {:phoenix_view, "~> 2.0"},
       {:floki, ">= 0.30.0", only: :test},


### PR DESCRIPTION
Because sqlite does not need a running server it is better for the purpose of this tutorial.

I tested only with versions:
```
$ elixir --version 
Erlang/OTP 26 [erts-14.0.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [jit:ns]

Elixir 1.15.0 (compiled with Erlang/OTP 26)
```
```
$ mix --version
Erlang/OTP 26 [erts-14.0.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [jit:ns]

Mix 1.15.0 (compiled with Erlang/OTP 26)
```